### PR TITLE
Fix setting of hostname and password and retaining it even after serv…

### DIFF
--- a/examples/environment.ubuntu-20-04.blackstack
+++ b/examples/environment.ubuntu-20-04.blackstack
@@ -5,10 +5,6 @@
 # - $2: Password for both the 'blackstack' Linux user and PostgreSQL user.
 # 
 
-# Map the parameters.
-RUN export HOSTNAME="$1"
-RUN export PASSWORD="$2"
-
 # Set timezone to America/Argentina/Buenos_Aires
 RUN timedatectl set-timezone "America/Argentina/Buenos_Aires"
 
@@ -16,13 +12,13 @@ RUN timedatectl set-timezone "America/Argentina/Buenos_Aires"
 RUN useradd -m -s /bin/bash blackstack
 
 # Set password for 'blackstack' user
-RUN echo "blackstack:$PASSWORD" | chpasswd
+RUN echo "blackstack:$2" | chpasswd
 
 # Add 'blackstack' to sudoers
 RUN usermod -aG sudo blackstack
 
 # Change hostname
-RUN hostnamectl set-hostname "$HOSTNAME"
+RUN hostnamectl set-hostname "$1"
 
 # Enable PasswordAuthentication in SSH config
 RUN sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config
@@ -67,7 +63,7 @@ RUN systemctl restart postgresql
 RUN sudo -u postgres createuser -s blackstack
 
 # Set password for PostgreSQL user 'blackstack'
-RUN sudo -u postgres psql -c "ALTER USER blackstack WITH PASSWORD '$PASSWORD';"
+RUN sudo -u postgres psql -c "ALTER USER blackstack WITH PASSWORD '$2';"
 
 # Create new database 'blackstack' owned by user 'blackstack'
 RUN sudo -u postgres createdb -O blackstack blackstack


### PR DESCRIPTION
1. Script should run succesfully
<img width="814" alt="Screenshot 2024-09-17 at 5 17 15 PM" src="https://github.com/user-attachments/assets/c00c1cdb-368b-4820-a753-7add5850eb16">

2. The hostname of the VPS must be configured as required in parameter $1
<img width="983" alt="Screenshot 2024-09-17 at 5 17 51 PM" src="https://github.com/user-attachments/assets/d6715200-f694-45b9-a0b3-07b44e591dee">

3. the hostname of the VPS must remains the same after a reboot (I noticed that it is rolled back, probably because a Contabo pre-configuration).
<img width="807" alt="Screenshot 2024-09-17 at 5 20 02 PM" src="https://github.com/user-attachments/assets/fdb96547-f84b-4294-b35b-e766d0041b36">

4.I must be capable to access the VPS via SSH with the Linux user blackstack and the password provided in parameter $2
[
<img width="983" alt="Screenshot 2024-09-17 at 5 17 51 PM" src="https://github.com/user-attachments/assets/ffb32744-fa06-464c-976b-3f9d4ae8eccc">
](url)

5.  I must be capable to access the PostgresSQL database with the user blackstack and the password provided in parameter $2.
<img width="798" alt="Screenshot 2024-09-17 at 5 23 21 PM" src="https://github.com/user-attachments/assets/0195c3d2-2512-40a6-89d9-a73828243512">

6.  All the other packages and software pieces (Ruby, AdsPower, ChromeDriver, etc. etc.) listed in the configuration file must be operative when I access the VPS via SSH with the Linux user blackstack.
<img width="770" alt="Screenshot 2024-09-17 at 5 24 30 PM" src="https://github.com/user-attachments/assets/2ee1cece-e959-4b72-9eda-70ff36dd9913">

